### PR TITLE
Add support for exynos7870 in libhwc

### DIFF
--- a/libdisplay/Android.mk
+++ b/libdisplay/Android.mk
@@ -49,7 +49,7 @@ endif
 # old kernel APIs for calling it (S3C_FB_*).
 # Newer SoCs (Exynos 7420 onwards) make use of a new kernel API.
 # WARNING: Support is highly experimental!
-ifneq ($(filter exynos7870 exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos3475 exynos7420 exynos7580 exynos7870 exynos7880 exynos8890, $(TARGET_SOC)),)
 	LOCAL_CFLAGS += -DDECON_FB
 endif
 

--- a/libdisplay/Android.mk
+++ b/libdisplay/Android.mk
@@ -49,7 +49,7 @@ endif
 # old kernel APIs for calling it (S3C_FB_*).
 # Newer SoCs (Exynos 7420 onwards) make use of a new kernel API.
 # WARNING: Support is highly experimental!
-ifneq ($(filter exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos7870 exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
 	LOCAL_CFLAGS += -DDECON_FB
 endif
 

--- a/libhwc/Android.mk
+++ b/libhwc/Android.mk
@@ -88,7 +88,7 @@ endif
 # old kernel APIs for calling it (S3C_FB_*).
 # Newer SoCs (Exynos 7420 onwards) make use of a new kernel API.
 # WARNING: Support is highly experimental!
-ifneq ($(filter exynos7870 exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos3475 exynos7420 exynos7580 exynos7870 exynos7880 exynos8890, $(TARGET_SOC)),)
 	LOCAL_CFLAGS += -DDECON_FB
 endif
 

--- a/libhwc/Android.mk
+++ b/libhwc/Android.mk
@@ -88,7 +88,7 @@ endif
 # old kernel APIs for calling it (S3C_FB_*).
 # Newer SoCs (Exynos 7420 onwards) make use of a new kernel API.
 # WARNING: Support is highly experimental!
-ifneq ($(filter exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos7870 exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
 	LOCAL_CFLAGS += -DDECON_FB
 endif
 

--- a/libhwcutils/Android.mk
+++ b/libhwcutils/Android.mk
@@ -47,7 +47,7 @@ endif
 # old kernel APIs for calling it (S3C_FB_*).
 # Newer SoCs (Exynos 7420 onwards) make use of a new kernel API.
 # WARNING: Support is highly experimental!
-ifneq ($(filter exynos7870 exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos3475 exynos7420 exynos7580 exynos7870 exynos7880 exynos8890, $(TARGET_SOC)),)
 	LOCAL_CFLAGS += -DDECON_FB
 endif
 

--- a/libhwcutils/Android.mk
+++ b/libhwcutils/Android.mk
@@ -47,7 +47,7 @@ endif
 # old kernel APIs for calling it (S3C_FB_*).
 # Newer SoCs (Exynos 7420 onwards) make use of a new kernel API.
 # WARNING: Support is highly experimental!
-ifneq ($(filter exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos7870 exynos3475 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
 	LOCAL_CFLAGS += -DDECON_FB
 endif
 

--- a/libvideocodec/Android.mk
+++ b/libvideocodec/Android.mk
@@ -34,7 +34,7 @@ ifeq ($(BOARD_USE_HEVC_HWIP), true)
 LOCAL_CFLAGS += -DUSE_HEVC_HWIP
 endif
 
-ifneq ($(filter exynos3475 exynos5422 exynos5430 exynos5433 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos7870 exynos3475 exynos5422 exynos5430 exynos5433 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
 LOCAL_CFLAGS += -DNEW_API
 endif
 

--- a/libvideocodec/Android.mk
+++ b/libvideocodec/Android.mk
@@ -34,7 +34,7 @@ ifeq ($(BOARD_USE_HEVC_HWIP), true)
 LOCAL_CFLAGS += -DUSE_HEVC_HWIP
 endif
 
-ifneq ($(filter exynos7870 exynos3475 exynos5422 exynos5430 exynos5433 exynos7420 exynos7580 exynos7880 exynos8890, $(TARGET_SOC)),)
+ifneq ($(filter exynos3475 exynos5422 exynos5430 exynos5433 exynos7420 exynos7580 exynos7870 exynos7880 exynos8890, $(TARGET_SOC)),)
 LOCAL_CFLAGS += -DNEW_API
 endif
 


### PR DESCRIPTION
Builds fail without it for this series of devices.